### PR TITLE
Refactoring `aiotdlib_generator.parser.utils` module

### DIFF
--- a/aiotdlib_generator/parser/utils.py
+++ b/aiotdlib_generator/parser/utils.py
@@ -10,7 +10,7 @@ def lower_first(s: str):
 
 
 def snake_case(s: str):
-    if not str:
+    if not s:
         return ""
 
     s = re.sub(r'(.)([A-Z][a-z]+)', r'\1_\2', s)

--- a/aiotdlib_generator/parser/utils.py
+++ b/aiotdlib_generator/parser/utils.py
@@ -1,15 +1,15 @@
 import re
 
 
-def upper_first(s: str):
+def upper_first(s: str) -> str:
     return s[:1].upper() + s[1:]
 
 
-def lower_first(s: str):
+def lower_first(s: str) -> str:
     return s[:1].lower() + s[1:]
 
 
-def snake_case(s: str):
+def snake_case(s: str) -> str:
     if not s:
         return ""
 

--- a/aiotdlib_generator/parser/utils.py
+++ b/aiotdlib_generator/parser/utils.py
@@ -10,6 +10,12 @@ def lower_first(s: str) -> str:
 
 
 def snake_case(s: str) -> str:
+    """
+    Convert camel case string to snake case.
+
+    :param s: Some camel case string
+    :return: Snake case string
+    """
     if not s:
         return ""
 


### PR DESCRIPTION
Hi, @pylakey! I made some refactoring in `aiotdlib_generator.parser.utils` module:
1. [Fix redundant check for snake_case function](https://github.com/pylakey/aiotdlib/commit/6c4ff3d3a1ec1032133badcd4893d6b329984ac3)
2. [Add returning annotation type](https://github.com/pylakey/aiotdlib/commit/2e5b16850bc1be409c4f86976de607bf9b6e31c9)
3. [Add docstring for snake_case function](https://github.com/pylakey/aiotdlib/commit/30fd4951078080a4ea817f323db9f7e068ff47e3). I wanted to change function name because it doesn't quite fit. It converts camels case to snake case (it doesn't handle another notations). This function would be named `camel_case_to_snake_case` but this name is too long. So I added an explanation in the docstring form. 