### PR TITLE
Add support for FreeBSD on x86-64

### DIFF
--- a/aiotdlib/tdjson.py
+++ b/aiotdlib/tdjson.py
@@ -20,6 +20,7 @@ ARCH_ALIASES = {
 SYSTEM_LIB_EXTENSION = {
     'darwin': 'dylib',
     'linux': 'so',
+    'freebsd': 'so',
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ include = [
 classifiers = [
     "Framework :: AsyncIO",
     "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: POSIX :: BSD :: FreeBSD",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]


### PR DESCRIPTION
This MR adds the TDLib binary for FreeBSD and specifies the list of supported OSes for PyPI (closes #62).

Steps to build TDLib on FreeBSD:

```sh
git clone https://github.com/tdlib/td tdlib
cd tdlib
git checkout 7eabd8ca60de025e45e99d4e5edd39f4ebd9467e   # check out tdlib v1.8.4
mkdir build && cd build
cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:PATH=. -DTD_ENABLE_LTO=ON -G Ninja ..
cmake --build . --target install --parallel
strip --strip-all ./lib/libtdjson.so.1.8.4
cp ./lib/libtdjson.so.1.8.4 "$AIOTDLIB_ROOT/tdlib/libtdjson_freebsd_amd64.so"
```