### PR TITLE
Support non-CLI authorization process, add some basic tests

### DIFF
--- a/aiotdlib/authorization.py
+++ b/aiotdlib/authorization.py
@@ -1,0 +1,224 @@
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from aiotdlib import Client, Handler
+    from aiotdlib.client import AuthActions
+    from aiotdlib.api import AuthorizationState
+
+from aiotdlib.api import SetOption, OptionValueBoolean, CheckAuthenticationBotToken, \
+    PhoneNumberAuthenticationSettings, SetAuthenticationPhoneNumber, CheckAuthenticationPassword, RegisterUser, \
+    EmailAddressAuthenticationCode, CheckAuthenticationEmailCode, SetAuthenticationEmailAddress, \
+    CheckAuthenticationCode, API, GetAuthorizationState, Error
+from aiotdlib.utils import ainput
+
+
+class AuthorizationHandler(ABC):
+    def __init__(self):
+        self.client: 'Client | None' = None
+
+    def set_client(self, client: 'Client'):
+        self.client = client
+
+    async def authorize(self):
+        await self.client.send(
+            GetAuthorizationState()
+        )
+
+    @abstractmethod
+    async def on_authorization_update(self, authorization_state: 'AuthorizationState'):
+        pass
+
+
+class NoOpAuthorizationHandler(AuthorizationHandler):
+    async def on_authorization_update(self, authorization_state: 'AuthorizationState'):
+        pass
+
+
+class CliAuthorizationHandler(AuthorizationHandler):
+    def __init__(self):
+        super().__init__()
+        self._authorized_future: asyncio.Future | None = None
+        self.logger = logging.getLogger(__name__)
+        self.error_handler: Handler | None = None
+
+    async def authorize(self):
+        if not bool(self.client.settings.phone_number) and not bool(self.client.settings.bot_token):
+            raise ValueError('Either phone_number or bot_token should be specified')
+
+        if self.client.is_bot:
+            self.logger.info('Authorization process has been started with bot token')
+        elif self.client.settings.phone_number:
+            self.logger.info('Authorization process has been started with phone')
+
+        self._authorized_future = asyncio.get_running_loop().create_future()
+        self.error_handler = self.client.add_event_handler(self.on_error, update_type=API.Types.ERROR)
+
+        await super().authorize()
+
+        self.logger.info('Waiting for authorization to be completed')
+        await self._authorized_future
+
+    async def on_error(self, _: 'Client', update: Error):
+        # These can be ignored
+        if update.message == "Option can't be set":
+            return
+        if self.error_handler is not None:
+            self.client.remove_event_handler(self.error_handler, update_type=API.Types.ERROR)
+            self.error_handler = None
+        if self._authorized_future is not None:
+            self._authorized_future.set_exception(ValueError(update.message))
+
+    async def on_authorization_update(self, authorization_state: 'AuthorizationState'):
+        auth_actions: 'AuthActions' = {
+            API.Types.AUTHORIZATION_STATE_WAIT_PHONE_NUMBER: self._set_authentication_phone_number_or_check_bot_token,
+            API.Types.AUTHORIZATION_STATE_WAIT_CODE: self._check_authentication_code,
+            API.Types.AUTHORIZATION_STATE_WAIT_EMAIL_ADDRESS: self._set_authentication_email_address,
+            API.Types.AUTHORIZATION_STATE_WAIT_EMAIL_CODE: self._check_authentication_email_code,
+            API.Types.AUTHORIZATION_STATE_WAIT_REGISTRATION: self._register_user,
+            API.Types.AUTHORIZATION_STATE_WAIT_PASSWORD: self._check_authentication_password,
+            API.Types.AUTHORIZATION_STATE_READY: self._auth_completed,
+            # TODO: QR Login support
+            # API.Types.AUTHORIZATION_STATE_WAIT_OTHER_DEVICE_CONFIRMATION: None,
+        }
+        action = auth_actions.get(authorization_state.ID)
+        if bool(action):
+            await action(authorization_state)
+
+    async def _set_authentication_phone_number_or_check_bot_token(self, *_):
+        await self.client.send(SetOption(name='online', value=OptionValueBoolean(value=True)))
+
+        if self.client.is_bot:
+            return await self._check_authentication_bot_token()
+
+        return await self._set_authentication_phone_number()
+
+    async def _set_authentication_phone_number(self, *_):
+        self.logger.info('Sending phone number')
+        await self.client.send(
+            SetAuthenticationPhoneNumber(
+                phone_number=self.client.settings.phone_number,
+                settings=PhoneNumberAuthenticationSettings(
+                    allow_flash_call=False,
+                    allow_missed_call=False,
+                    is_current_phone_number=True,
+                    allow_sms_retriever_api=False,
+                    authentication_tokens=[]
+                ),
+            )
+        )
+
+    async def _check_authentication_bot_token(self, *_):
+        self.logger.info('Sending bot token')
+        await self.client.send(
+            CheckAuthenticationBotToken(
+                token=self.client.settings.bot_token.get_secret_value(),
+            )
+        )
+
+    async def _check_authentication_code(self, authorization_state: 'AuthorizationState'):
+        code = await self._auth_get_code(code_type='SMS', expected_length=authorization_state.code_info.type_.length)
+        self.logger.info(f'Sending code {code}')
+        await self.client.send(
+            CheckAuthenticationCode(
+                code=code,
+            )
+        )
+
+    async def _set_authentication_email_address(self, *_):
+        email_address = await self._auth_get_email()
+        await self.client.send(
+            SetAuthenticationEmailAddress(
+                email_address=email_address,
+            )
+        )
+
+    async def _check_authentication_email_code(self, *_):
+        code = await self._auth_get_code(code_type='EMail')
+        self.logger.info(f'Sending email code {code}')
+        return await self.client.send(
+            CheckAuthenticationEmailCode(
+                code=EmailAddressAuthenticationCode(
+                    code=code
+                ),
+            )
+        )
+
+    async def _register_user(self, *_):
+        first_name = await self._auth_get_first_name()
+        last_name = await self._auth_get_last_name()
+        self.logger.info(f'Registering new user in telegram as {first_name} {last_name or ""}'.strip())
+        await self.client.send(
+            RegisterUser(
+                first_name=first_name,
+                last_name=last_name,
+            )
+        )
+
+    async def _check_authentication_password(self, *_):
+        password = await self._auth_get_password()
+        self.logger.info('Sending password')
+        await self.client.send(
+            CheckAuthenticationPassword(
+                password=password,
+            )
+        )
+
+    async def _auth_completed(self, *_):
+        if self._authorized_future is None:
+            self.logger.warning('Authorization finished before it was initiated')
+        elif not self._authorized_future.done():
+            if self.error_handler is not None:
+                self.client.remove_event_handler(self.error_handler, update_type=API.Types.ERROR)
+                self.error_handler = None
+            self._authorized_future.set_result(None)
+
+        # if not self.client.is_bot:
+        #     # Preload main list chats
+        #     await self.client.get_main_list_chats()
+
+    # noinspection PyMethodMayBeStatic
+    async def _auth_get_code(self, *, code_type: str = 'SMS', expected_length: int = 5) -> str:
+        code = ""
+
+        while len(code) != expected_length or not code.isdigit():
+            code = await ainput(f'Enter {code_type} code of length {expected_length}:')
+
+        return code
+
+    async def _auth_get_password(self) -> str:
+        password = self.client.settings.password
+
+        if not bool(password):
+            password = await ainput('Enter 2FA password:', secured=True)
+        else:
+            password = password.get_secret_value()
+
+        return password
+
+    async def _auth_get_first_name(self) -> str:
+        first_name = self.client.settings.first_name or ""
+
+        while not bool(first_name) or len(first_name) > 64:
+            first_name = await ainput('Enter first name:')
+
+        return first_name
+
+    async def _auth_get_last_name(self) -> str:
+        last_name = self.client.settings.last_name or ""
+
+        if not bool(last_name):
+            last_name = await ainput('Enter last name:')
+
+        return last_name
+
+    async def _auth_get_email(self) -> str:
+        email = self.client.settings.email or ""
+
+        if not bool(email):
+            email = await ainput('Enter your email:')
+
+        return email

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dev = [
     "Jinja2>=3.1.3",
     "pydash>=7.0.4",
     "black>=23.3,<25.0",
+    "pytest>=8.3.4",
+    "pytest-asyncio>=0.25.0",
 ]
 
 [project.urls]
@@ -69,4 +71,13 @@ exclude = [
 only-packages = true
 artifacts = [
     "aiotdlib/tdlib/*",
+]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--import-mode=importlib --log-cli-level=DEBUG"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+testpaths = [
+    "tests",
 ]

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,35 @@
+# aiotdlib Tests
+
+## Running the tests
+
+### Setup
+
+To run the tests, you must set the following environment variables in your test environment
+
+| Environment Variable  | Note                                                             |
+|-----------------------|------------------------------------------------------------------|
+| AIOTDLIB_API_ID       | Your API ID from <https://my.telegram.org/apps>                  |
+| AIOTDLIB_API_HASH     | Your API Hash from <https://my.telegram.org/apps>                |
+| AIOTDLIB_PHONE_NUMBER | Phone number in international format registered in production DC |
+
+In PyCharm, you can do this by creating a `pytest` Run/Debug configuration with
+a `script` target of `/path/to/aiotdlib/tests`, working directory of `/path/to/aiotdlib/tests`
+and Environment Variables of the above variables separated by semicolons.
+
+### Test execution
+
+When running the tests that require a real account, you can't get around receiving
+an MFA code from Telegram. To support this, the login process will read a code from 
+the file `tests/code.txt`. When launching the tests, make sure you're logged in to
+the same account from another Telegram app. Once you receive the MFA code from Telegram,
+copy and paste it into `tests/code.txt` and save the file. Don't worry about extra
+spaces / newlines. The test process will pick up the code and then overwrite the file
+so it's empty for next time.
+
+For non-login tests, the default storage directory will be used, and it will _not_
+be wiped in between tests - therefore, after the first login you should not need
+to repeat the login process again.
+
+### Account requirements
+
+Currently, the tests only require that your account is a member of at least one chat.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+from typing import Any
+
+import pytest
+from pytest_asyncio import is_async_test
+
+from shared_client import authorizer, client
+
+__all__ = ['authorizer', 'client']
+
+
+# https://github.com/pytest-dev/pytest-asyncio/issues/983
+def pytest_collection_modifyitems(items: Any) -> None:
+    """
+    Make all tests run on the same event loop.
+
+    This is necessary because our TDLib needs to be configured/authenticated
+    as a fixture from the same event loop where we send messages within a test,
+    otherwise the update thread hangs.
+    See: https://pytest-asyncio.readthedocs.io/en/latest/how-to-guides/run_session_tests_in_same_loop.html
+    """
+    pytest_asyncio_tests = (item for item in items if is_async_test(item))
+    session_scope_marker = pytest.mark.asyncio(loop_scope="session")
+    for async_test in pytest_asyncio_tests:
+        async_test.add_marker(session_scope_marker, append=False)

--- a/tests/shared_client.py
+++ b/tests/shared_client.py
@@ -1,0 +1,63 @@
+import asyncio
+import os
+
+import pytest_asyncio
+from pydantic import SecretStr
+
+from aiotdlib import Client, ClientSettings
+from aiotdlib.authorization import CliAuthorizationHandler
+
+CODE_RECEIVE_TIMEOUT_SECS = 60
+TEST_API_ID = os.environ.get("AIOTDLIB_API_ID")
+TEST_API_HASH = os.environ.get("AIOTDLIB_API_HASH")
+TEST_PHONE_NUMBER = os.environ.get("AIOTDLIB_PHONE_NUMBER")
+
+if not TEST_API_ID or not TEST_API_HASH or not TEST_PHONE_NUMBER:
+    raise ValueError("Missing environment variables")
+
+
+class TestAuthorizationHandler(CliAuthorizationHandler):
+    def __init__(self):
+        super().__init__()
+
+    async def _auth_get_code(self, *, code_type: str = 'SMS', expected_length: int = 5) -> str:
+        self.logger.info("Waiting for code...")
+        for _ in range(CODE_RECEIVE_TIMEOUT_SECS):
+            with open('code.txt', 'r') as f:
+                code = f.read()
+            if len(code) != 0:
+                with open('code.txt', 'w'):
+                    pass  # truncate file for next run
+                return code.strip()
+            await asyncio.sleep(1)
+        raise ValueError("Code was not provided")
+
+    async def _auth_get_password(self) -> str:
+        raise NotImplemented
+
+    async def _auth_get_first_name(self) -> str:
+        raise NotImplemented
+
+    async def _auth_get_last_name(self) -> str:
+        raise NotImplemented
+
+    async def _auth_get_email(self) -> str:
+        raise NotImplemented
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def authorizer() -> TestAuthorizationHandler:
+    return TestAuthorizationHandler()
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def client(authorizer: TestAuthorizationHandler) -> Client:
+    async with Client(settings=ClientSettings(
+        authorization_handler=authorizer,
+        api_id=int(TEST_API_ID),
+        api_hash=SecretStr(TEST_API_HASH),
+        phone_number=TEST_PHONE_NUMBER,
+        session_name="aiotdlib-test",
+        #tdlib_verbosity=TDLibLogVerbosity.VERBOSE
+    )) as client:
+        yield client

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,13 @@
+
+from aiotdlib import Client
+
+
+async def test_me(client: Client) -> None:
+    my_info = await client.api.get_me()
+    assert my_info is not None
+    assert my_info.id is not None
+
+
+async def test_chats(client: Client) -> None:
+    chats = await client.get_main_list_chats(limit=1)
+    assert len(chats) == 1

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,133 @@
+import asyncio
+import os
+import pathlib
+
+import pytest
+import pytest_asyncio
+from pydantic import SecretStr
+
+from aiotdlib import Client, ClientSettings
+from aiotdlib.authorization import CliAuthorizationHandler
+
+CODE_RECEIVE_TIMEOUT_SECS = 60
+TEST_DC_NUMBER = 2
+TEST_DC_PHONE_NUMBER = "9996629845"
+
+TEST_DO_REAL_LOGIN = os.environ.get("AIOTDLIB_TEST_DO_REAL_LOGIN")
+TEST_API_ID = os.environ.get("AIOTDLIB_API_ID")
+TEST_API_HASH = os.environ.get("AIOTDLIB_API_HASH")
+TEST_PHONE_NUMBER = os.environ.get("AIOTDLIB_PHONE_NUMBER")
+
+if not TEST_API_ID or not TEST_API_HASH or not TEST_PHONE_NUMBER:
+    raise ValueError("Missing environment variables")
+
+
+# https://core.telegram.org/api/auth#test-accounts
+class TestDcAuthorizationHandler(CliAuthorizationHandler):
+    def __init__(self, code: str | None):
+        super().__init__()
+        self.code_was_sent = False
+        self.code = code
+
+    async def _auth_get_code(self, *, code_type: str = 'SMS', expected_length: int = 5) -> str:
+        if self.code is not None:
+            return self.code if len(self.code) > 1 else self.code * expected_length
+        else:
+            self.logger.info("Waiting for code...")
+            for _ in range(CODE_RECEIVE_TIMEOUT_SECS):
+                with open('code.txt', 'r') as f:
+                    code = f.read()
+                if len(code) != 0:
+                    with open('code.txt', 'w'):
+                        pass  # truncate file for next run
+                    return code.strip()
+                self.code_was_sent = True
+                await asyncio.sleep(1)
+            raise ValueError("Code was not provided")
+
+    async def _auth_get_password(self) -> str:
+        raise NotImplemented
+
+    async def _auth_get_first_name(self) -> str:
+        raise NotImplemented
+
+    async def _auth_get_last_name(self) -> str:
+        raise NotImplemented
+
+    async def _auth_get_email(self) -> str:
+        raise NotImplemented
+
+
+@pytest_asyncio.fixture(scope='function')
+async def authorizer_real() -> TestDcAuthorizationHandler:
+    return TestDcAuthorizationHandler(code=None)
+
+
+@pytest_asyncio.fixture(scope='function')
+async def client_real(authorizer_real: TestDcAuthorizationHandler, tmp_path: pathlib.Path) -> Client:
+    async with Client(settings=ClientSettings(
+            authorization_handler=authorizer_real,
+            api_id=int(TEST_API_ID),
+            api_hash=SecretStr(TEST_API_HASH),
+            phone_number=TEST_PHONE_NUMBER,
+            use_test_dc=False,
+            # Ensure session info is cleaned up after tests finish
+            files_directory=tmp_path,
+    )) as client:
+        yield client
+
+
+@pytest_asyncio.fixture(scope='function')
+async def authorizer_test() -> TestDcAuthorizationHandler:
+    return TestDcAuthorizationHandler(code=str(TEST_DC_NUMBER))
+
+
+@pytest_asyncio.fixture(scope='function')
+async def client_test_dc(authorizer_test: TestDcAuthorizationHandler, tmp_path: pathlib.Path) -> Client:
+    async with Client(settings=ClientSettings(
+            authorization_handler=authorizer_test,
+            api_id=int(TEST_API_ID),
+            api_hash=SecretStr(TEST_API_HASH),
+            phone_number=TEST_DC_PHONE_NUMBER,
+            use_test_dc=True,
+            # Ensure session info is cleaned up after tests finish
+            files_directory=tmp_path,
+    )) as client:
+        yield client
+
+
+@pytest_asyncio.fixture(scope='function')
+async def authorizer_test_wrong_code() -> TestDcAuthorizationHandler:
+    return TestDcAuthorizationHandler(code='00000')
+
+
+@pytest.mark.skipif(not bool(TEST_DO_REAL_LOGIN),
+                    reason="Telegram rate limits logins to a small number per day. "
+                           "Skip this test unless the environment variable TEST_DO_REAL_LOGIN "
+                           "is set to a non-empty value.")
+@pytest.mark.asyncio(scope='function')
+async def test_client_real_login(client_real: Client) -> None:
+    assert getattr(client_real.settings.authorization_handler, 'code_was_sent', False)
+    assert client_real.is_authorized
+
+
+@pytest.mark.skip(reason="Test DC login not working https://github.com/tdlib/td/issues/3083")
+@pytest.mark.asyncio(scope='function')
+async def test_test_dc_login(client_test_dc: Client) -> None:
+    assert client_test_dc.is_authorized
+
+
+@pytest.mark.asyncio(scope='function')
+async def test_test_dc_wrong_code(authorizer_test_wrong_code: TestDcAuthorizationHandler,
+                                  tmp_path: pathlib.Path) -> None:
+    with pytest.raises(ValueError, match="PHONE_CODE_INVALID"):
+        async with Client(settings=ClientSettings(
+                authorization_handler=authorizer_test_wrong_code,
+                api_id=int(TEST_API_ID),
+                api_hash=SecretStr(TEST_API_HASH),
+                phone_number=TEST_DC_PHONE_NUMBER,
+                use_test_dc=True,
+                # Ensure session info is cleaned up after tests finish
+                files_directory=tmp_path
+        )):
+            assert False


### PR DESCRIPTION
I wanted to support a system where a user can log in to Telegram over a web server, meaning that the user won't be able to type MFA code in the Python program running aiotdlib. To do this, I refactored the authorization piece out into a separate class and made it use the existing CLI implementation by default. It also handles errors during authorization and throws an error rather than hanging (I found the test DC isn't accepting MFA codes recently).

This should be completely backwards compatible for existing users (but feel free to correct me if I'm wrong).

I also added some basic integration tests. Unfortunately, since they don't run in isolation there is required setup / environment variable configuration, but if you're interested in accepting this PR at least it's a starting point.

Let me know if you have any questions/concerns.